### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "league/csv": "^9.1"
     },
     "type": "magento2-module",
-    "version": "0.4.2",
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
This fixes potential packagist.org issues. See https://blog.packagist.com/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist/