### PR TITLE
don't use slash as an escape character

### DIFF
--- a/src/Streamer/FileCsv.php
+++ b/src/Streamer/FileCsv.php
@@ -89,6 +89,7 @@ class FileCsv
         $requestFile = fopen($requestFile, 'r');
 
         $csvReader = \League\Csv\Reader::createFromStream($requestFile);
+        $csvReader->setEscape('');
         if (empty($this->headers)) {
             $csvReader->setHeaderOffset(0);
         }


### PR DESCRIPTION
See: https://github.com/thephpleague/csv/issues/433

Gaat verkeerd als kolom op een slash eindigt, bijvoorbeeld: `UITL\`