### PR TITLE
fix: updated guzzle requirement to v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "",
     "require": {
         "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0",
-        "guzzlehttp/guzzle": "~6.0",
-        "prewk/xml-string-streamer": "^0.7.2",
-        "prewk/xml-string-streamer-guzzle": "^0.1.0",
+        "guzzlehttp/guzzle": "^7",
+        "prewk/xml-string-streamer": "^1.2",
+        "prewk/xml-string-streamer-guzzle": "^1.2",
         "kevinrob/guzzle-cache-middleware": "^1.4",
         "ecomdev/magento-psr6-bridge": "^0.2.1",
         "symfony/stopwatch": "~4.0",


### PR DESCRIPTION
necessary for magento 2.4.4 upgrade