### PR TITLE
fix: prevent passing null value as argument

### DIFF
--- a/src/Model/ImportProfile.php
+++ b/src/Model/ImportProfile.php
@@ -64,7 +64,7 @@ abstract class ImportProfile implements ImportProfileInterface
         ObjectManagerFactory $objectManagerFactory,
         Stopwatch $stopwatch,
         ConsoleOutput $consoleOutput,
-        Log $log
+        Log $log,
     ) {
         $this->objectManagerFactory = $objectManagerFactory;
         $this->stopwatch = $stopwatch;
@@ -104,8 +104,10 @@ abstract class ImportProfile implements ImportProfileInterface
             $this->consoleOutput->writeln($output);
             $this->log->info($output);
 
-            $this->consoleOutput->writeln("<error>$errors</error>");
-            $this->log->error($errors);
+            if ($errors) {
+                $this->consoleOutput->writeln("<error>$errors</error>");
+                $this->log->error($errors);
+            }
 
             $this->processedItems = $items;
             $this->errors = $errors;


### PR DESCRIPTION
prevents the following error:
Monolog\Logger::error(): Argument #1 ($message) must be of type Stringable|string, null given