### PR TITLE
fix: surface per-row errors with line + column (#26)

### DIFF
--- a/src/Model/ImportProfile.php
+++ b/src/Model/ImportProfile.php
@@ -109,6 +109,33 @@ abstract class ImportProfile implements ImportProfileInterface
                 $this->log->error($errors);
             }
 
+            // Issue #26: also surface per-row errors (line + column +
+            // message). validateSource passes when allowed_error_count
+            // permits the misses, but those rows are silently dropped —
+            // without this dump the developer only sees the summary
+            // "invalid rows: 4" and has no way to find them.
+            // Console output is capped at 100 so a wide-spread schema
+            // mismatch doesn't flood the terminal; the log file gets the
+            // full list either way.
+            $detailedErrors = $importer->getErrorMessages();
+            if (!empty($detailedErrors)) {
+                $total = count($detailedErrors);
+                $consoleCap = 100;
+                $this->consoleOutput->writeln(sprintf(
+                    '<comment>%d row-level error(s)%s:</comment>',
+                    $total,
+                    $total > $consoleCap
+                        ? sprintf(' — first %d shown (full list in log)', $consoleCap)
+                        : ''
+                ));
+                foreach ($detailedErrors as $i => $message) {
+                    $this->log->error($message);
+                    if ($i < $consoleCap) {
+                        $this->consoleOutput->writeln("  <error>$message</error>");
+                    }
+                }
+            }
+
             $this->processedItems = $items;
             $this->errors = $errors;
 

--- a/src/Model/Importer.php
+++ b/src/Model/Importer.php
@@ -133,18 +133,30 @@ class Importer
 
 
     /**
-     * Formatted array of error messages
-     * @return []\
+     * Formatted array of error messages — one string per validation /
+     * import error, ready to print or log. Each line reads:
+     *
+     *     Line <rownum>: [<column>] <message>  (— <description> if present)
+     *
+     * Designed for issue #26: the importer surfaces a summary
+     * ("Checked rows: 2822, invalid rows: 4, total errors: 4") but
+     * doesn't tell you which row or column went wrong. With this
+     * format a developer can grep straight to the offending line.
+     *
+     * @return string[]
      */
     public function getErrorMessages()
     {
         $errorAggregator = $this->importModel->getErrorAggregator();
         return array_map(function (ProcessingError $error) {
+            $column = $error->getColumnName();
+            $description = $error->getErrorDescription();
             return sprintf(
-                'Line %s: %s %s',
+                'Line %s: %s%s%s',
                 $error->getRowNumber() ?: '[?]',
+                $column ? "[$column] " : '',
                 $error->getErrorMessage(),
-                $error->getErrorDescription()
+                $description ? ' — ' . $description : ''
             );
         }, $errorAggregator->getAllErrors());
     }

--- a/src/Model/Importer.php
+++ b/src/Model/Importer.php
@@ -182,12 +182,34 @@ class Importer
     }
 
     /**
-     * Look up a row's natural identifier (sku / email) and format it
-     * for inclusion in the error message. Returns '' when the source
-     * isn't an in-memory array, the row isn't found, or no recognised
-     * identifier is present.
+     * Per-entity natural identifier columns, ordered from most-specific
+     * to least. First match wins:
      *
-     * @param array|null $dataArray
+     *   sku           — catalog_product, advanced_pricing, stock_items
+     *   source_code   — MSI stock_sources
+     *   email         — customer, customer_address, customer_composite
+     *   increment_id  — sales_order, invoice, credit_memo, shipment
+     *   code          — tax_rate, store / website CSV imports
+     *
+     * Override via DI (`<argument name="rowIdentifierFields" xsi:type="array">…`)
+     * if a custom entity type needs another column surfaced.
+     */
+    private const DEFAULT_ROW_IDENTIFIER_FIELDS = [
+        'sku',
+        'source_code',
+        'email',
+        'increment_id',
+        'code',
+    ];
+
+    /**
+     * Look up a row's natural identifier (sku / email / source_code /
+     * increment_id / code) and format it for inclusion in the error
+     * message. Returns '' when the source isn't an in-memory array,
+     * the row isn't found, or no recognised identifier is present —
+     * the caller still has the line number to work with.
+     *
+     * @param array|null      $dataArray
      * @param int|string|null $rowNumber
      * @return string
      */
@@ -197,8 +219,8 @@ class Importer
             return '';
         }
         $row = $dataArray[$rowNumber];
-        foreach (['sku', 'email'] as $field) {
-            if (!empty($row[$field])) {
+        foreach (self::DEFAULT_ROW_IDENTIFIER_FIELDS as $field) {
+            if (isset($row[$field]) && $row[$field] !== '') {
                 return sprintf(' (%s=%s)', $field, $row[$field]);
             }
         }

--- a/src/Model/Importer.php
+++ b/src/Model/Importer.php
@@ -185,14 +185,22 @@ class Importer
      * Per-entity natural identifier columns, ordered from most-specific
      * to least. First match wins:
      *
-     *   sku           — catalog_product, advanced_pricing, stock_items
+     *   sku           — catalog_product, advanced_pricing, stock_items,
+     *                   product_links
      *   source_code   — MSI stock_sources
-     *   email         — customer, customer_address, customer_composite
+     *   email         — customer, customer_address, customer_composite,
+     *                   newsletter_subscriber
      *   increment_id  — sales_order, invoice, credit_memo, shipment
      *   code          — tax_rate, store / website CSV imports
+     *   url_key       — catalog_category (primary), catalog_product (fallback)
+     *   request_path  — url_rewrite
+     *   name          — catalog_category (last resort — name isn't
+     *                   unique, but it's the only thing every category
+     *                   row carries)
      *
-     * Override via DI (`<argument name="rowIdentifierFields" xsi:type="array">…`)
-     * if a custom entity type needs another column surfaced.
+     * `sku` is checked first so product imports always show the SKU even
+     * when the row also has `url_key` or `name`. Category imports fall
+     * through to `url_key` / `name` since they don't have a SKU.
      */
     private const DEFAULT_ROW_IDENTIFIER_FIELDS = [
         'sku',
@@ -200,6 +208,9 @@ class Importer
         'email',
         'increment_id',
         'code',
+        'url_key',
+        'request_path',
+        'name',
     ];
 
     /**

--- a/src/Model/Importer.php
+++ b/src/Model/Importer.php
@@ -33,6 +33,16 @@ class Importer
     protected $arrayAdapterFactory;
 
     /**
+     * Reference to the data array passed into processImport — kept around
+     * so getErrorMessages() can resolve a row number back to its
+     * identifier (typically `sku`, falls back to `email` for customers).
+     * Magento's `ProcessingError` only carries the row number.
+     *
+     * @var array|null
+     */
+    private $lastDataArray;
+
+    /**
      * @var \Magento\Indexer\Model\Indexer\Collection
      */
     private $indexerCollection;
@@ -80,6 +90,7 @@ class Importer
      */
     public function processImport(&$dataArray)
     {
+        $this->lastDataArray = &$dataArray;
         $sourceAdapter = $this->loadData($dataArray);
         $validationResult = $this->importModel->validateSource($sourceAdapter);
         if (!$validationResult) {
@@ -136,29 +147,62 @@ class Importer
      * Formatted array of error messages — one string per validation /
      * import error, ready to print or log. Each line reads:
      *
-     *     Line <rownum>: [<column>] <message>  (— <description> if present)
+     *     Line <rownum> (<id-field>=<value>): [<column>] <message>  (— <description> if present)
      *
      * Designed for issue #26: the importer surfaces a summary
      * ("Checked rows: 2822, invalid rows: 4, total errors: 4") but
      * doesn't tell you which row or column went wrong. With this
-     * format a developer can grep straight to the offending line.
+     * format a developer can grep straight to the offending row by
+     * line number, SKU, or email.
+     *
+     * SKU/email lookup is best-effort: it requires the source to be
+     * an in-memory array (the usual ArrayAdapter path). For other
+     * source types — CSV files, HTTP streams — `lastDataArray` stays
+     * null and the line number alone is shown.
      *
      * @return string[]
      */
     public function getErrorMessages()
     {
         $errorAggregator = $this->importModel->getErrorAggregator();
-        return array_map(function (ProcessingError $error) {
+        $dataArray = $this->lastDataArray;
+        return array_map(function (ProcessingError $error) use ($dataArray) {
+            $rowNumber = $error->getRowNumber();
             $column = $error->getColumnName();
             $description = $error->getErrorDescription();
             return sprintf(
-                'Line %s: %s%s%s',
-                $error->getRowNumber() ?: '[?]',
+                'Line %s%s: %s%s%s',
+                $rowNumber ?? '[?]',
+                $this->formatRowIdentifier($dataArray, $rowNumber),
                 $column ? "[$column] " : '',
                 $error->getErrorMessage(),
                 $description ? ' — ' . $description : ''
             );
         }, $errorAggregator->getAllErrors());
+    }
+
+    /**
+     * Look up a row's natural identifier (sku / email) and format it
+     * for inclusion in the error message. Returns '' when the source
+     * isn't an in-memory array, the row isn't found, or no recognised
+     * identifier is present.
+     *
+     * @param array|null $dataArray
+     * @param int|string|null $rowNumber
+     * @return string
+     */
+    private function formatRowIdentifier($dataArray, $rowNumber): string
+    {
+        if (!is_array($dataArray) || $rowNumber === null || !isset($dataArray[$rowNumber])) {
+            return '';
+        }
+        $row = $dataArray[$rowNumber];
+        foreach (['sku', 'email'] as $field) {
+            if (!empty($row[$field])) {
+                return sprintf(' (%s=%s)', $field, $row[$field]);
+            }
+        }
+        return '';
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #26.

The issue: an import that runs with `validation-skip-errors` (the common pattern) prints a summary —

```
Checked rows: 2822, checked entities: 5640, invalid rows: 4, total errors: 4, The import was successful.
2822 items imported in 1.2 sec, 2422.3 items / sec (208.5mb used)
```

— and tells you nothing about *which* four rows broke. The error aggregator already holds the row numbers and column names; nothing was printing them.

Three small changes:

* **`Importer::getErrorMessages()`** folds `ProcessingError::getColumnName()` into the formatted string. Each entry reads `Line N (sku=…): [<column>] <message> — <description>` instead of the original `Line N: <message> <description>`.

* **`Importer` keeps a reference to the data array** passed into `processImport()` so the error message can resolve a row number back to its `sku` (catalog) or `email` (customer). Lookup is best-effort — for non-array sources (CSV files, HTTP streams) the identifier piece is dropped and the line number alone is shown.

* **`ImportProfile::run()`** now always calls `getErrorMessages()` after the import (not just when the summary trace is truthy — `processImport()` returns `null` when validation passes but skipped rows still piled up in the aggregator) and emits each error to both the log and the console. Console output is capped at 100 lines so a wide-spread schema mismatch doesn't flood the terminal; the log file gets every error either way.

## Output sample (real local test)

Before:

```
2 items imported in 0.0 sec, ...
```

After:

```
2 items imported in 0.0 sec, ...
1 row-level error(s):
  Line 1 (sku=TEST-BAD): [visibility] Value for 'visibility' attribute contains incorrect value, see acceptable values on settings specified for Admin
```

## Test plan

- [x] Sanity-tested on project-jumbosports-m2 with a synthetic 2-item batch (one valid, one with a bogus visibility value) — patched code output above.
- [ ] Nothing automated yet — `src/Model/` has no PHPUnit harness in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)